### PR TITLE
Refactor case pages to use shared layout and header

### DIFF
--- a/_includes/case-header.html
+++ b/_includes/case-header.html
@@ -1,0 +1,6 @@
+<header class="case-header" style="background:rgba(255,255,255,0.8);padding:10px 20px;">
+  <div class="container" style="display:flex;justify-content:space-between;align-items:center;">
+    <a href="/index.html" class="logo" style="font-weight:bold;text-decoration:none;color:#333;">Swer4ock</a>
+    <a href="/index.html" class="back-link" style="text-decoration:none;color:#333;">← Назад к портфолио</a>
+  </div>
+</header>

--- a/_layouts/case-template.html
+++ b/_layouts/case-template.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ page.title }}</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  {% include case-header.html %}
+  {{ content }}
+</body>
+</html>

--- a/aigolos-bot-case.html
+++ b/aigolos-bot-case.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html>
-<html lang="ru">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AiGolos Bot - Финансовый коуч-бот</title>
-    <style>
+---
+layout: case-template
+title: AiGolos Bot - Финансовый коуч-бот
+---
+<article>
+<style>
         * {
             margin: 0;
             padding: 0;
@@ -219,8 +218,7 @@
             }
         }
     </style>
-</head>
-<body>
+
     <div class="container">
         <div class="hero">
             <div class="badge">💰 AI Assistant</div>
@@ -414,9 +412,6 @@ async def handle_message(update: Update, context: CallbackContext) -> None:
             </div>
         </div>
 
-        <div style="text-align: center; margin-top: 40px;">
-            <a href="index.html" class="back-btn">← Вернуться в портфолио</a>
         </div>
-    </div>
-</body>
-</html>
+
+</article>

--- a/crm-voice-analytics-case.html
+++ b/crm-voice-analytics-case.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html>
-<html lang="ru">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>CRM Voice Analytics - Интеграция AmoCRM + Sipuni + AI</title>
-    <style>
+---
+layout: case-template
+title: CRM Voice Analytics - Интеграция AmoCRM + Sipuni + AI
+---
+<article>
+<style>
         * {
             margin: 0;
             padding: 0;
@@ -205,8 +204,7 @@
             }
         }
     </style>
-</head>
-<body>
+
     <div class="container">
         <div class="header">
             <div class="badge">🔥 НОВЫЙ ПРОЕКТ</div>
@@ -528,9 +526,6 @@ for t in threads:
             </div>
         </div>
 
-        <div style="text-align: center; margin-top: 40px;">
-            <a href="index.html" class="back-btn">← Вернуться в портфолио</a>
         </div>
-    </div>
-</body>
-</html>
+
+</article>

--- a/erp-system-case.html
+++ b/erp-system-case.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html>
-<html lang="ru">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ERP System - Система управления складом</title>
-    <style>
+---
+layout: case-template
+title: ERP System - Система управления складом
+---
+<article>
+<style>
         * {
             margin: 0;
             padding: 0;
@@ -234,8 +233,7 @@
             }
         }
     </style>
-</head>
-<body>
+
     <div class="container">
         <div class="hero">
             <div class="badge">🏢 Enterprise System</div>
@@ -436,9 +434,6 @@ python manage.py collectstatic</div>
             </div>
         </div>
 
-        <div style="text-align: center; margin-top: 40px;">
-            <a href="index.html" class="back-btn">← Вернуться в портфолио</a>
         </div>
-    </div>
-</body>
-</html>
+
+</article>

--- a/gorobots-case.html
+++ b/gorobots-case.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html>
-<html lang="ru">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>GoRobots - Telegram MCP сервис</title>
-    <style>
+---
+layout: case-template
+title: GoRobots - Telegram MCP сервис
+---
+<article>
+<style>
         * {
             margin: 0;
             padding: 0;
@@ -219,8 +218,7 @@
             }
         }
     </style>
-</head>
-<body>
+
     <div class="container">
         <div class="hero">
             <div class="badge">🤖 MCP Service</div>
@@ -470,9 +468,6 @@ async def validate_api_key(request: Request, call_next):
             </div>
         </div>
 
-        <div style="text-align: center; margin-top: 40px;">
-            <a href="index.html" class="back-btn">← Вернуться в портфолио</a>
         </div>
-    </div>
-</body>
-</html>
+
+</article>

--- a/hubbery-case.html
+++ b/hubbery-case.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html>
-<html lang="ru">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Hubbery - WB фулфилмент система</title>
-    <style>
+---
+layout: case-template
+title: Hubbery - WB фулфилмент система
+---
+<article>
+<style>
         * {
             margin: 0;
             padding: 0;
@@ -219,8 +218,7 @@
             }
         }
     </style>
-</head>
-<body>
+
     <div class="container">
         <div class="hero">
             <div class="badge">📦 Fulfillment System</div>
@@ -474,9 +472,6 @@ function create_supply($name) {
             </div>
         </div>
 
-        <div style="text-align: center; margin-top: 40px;">
-            <a href="index.html" class="back-btn">← Вернуться в портфолио</a>
         </div>
-    </div>
-</body>
-</html>
+
+</article>

--- a/marketplace-optimization-case.html
+++ b/marketplace-optimization-case.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html>
-<html lang="ru">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Оптимизация товарных меток маркетплейсов | Кейс</title>
-    <style>
+---
+layout: case-template
+title: Оптимизация товарных меток маркетплейсов | Кейс
+---
+<article>
+<style>
         * {
             margin: 0;
             padding: 0;
@@ -269,8 +268,7 @@
             }
         }
     </style>
-</head>
-<body>
+
     <div class="container">
         <header class="case-header">
             <h1>🏷️ Оптимизация товарных меток</h1>
@@ -476,5 +474,5 @@
             </a>
         </div>
     </div>
-</body>
-</html>
+
+</article>

--- a/pumpfun-bot-case.html
+++ b/pumpfun-bot-case.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html>
-<html lang="ru">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>PumpFun Bot - Solana DeFi автоматизация</title>
-    <style>
+---
+layout: case-template
+title: PumpFun Bot - Solana DeFi автоматизация
+---
+<article>
+<style>
         * {
             margin: 0;
             padding: 0;
@@ -227,8 +226,7 @@
             }
         }
     </style>
-</head>
-<body>
+
     <div class="container">
         <div class="hero">
             <div class="badge">⚡ DeFi Automation</div>
@@ -449,9 +447,6 @@ async def send_jito_bundle(transactions: List[Transaction], tip_amount: int):
             </div>
         </div>
 
-        <div style="text-align: center; margin-top: 40px;">
-            <a href="index.html" class="back-btn">← Вернуться в портфолио</a>
         </div>
-    </div>
-</body>
-</html>
+
+</article>

--- a/telebot-creator-case.html
+++ b/telebot-creator-case.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html>
-<html lang="ru">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>TeleBotWebCreator - Конструктор Telegram-ботов</title>
-    <style>
+---
+layout: case-template
+title: TeleBotWebCreator - Конструктор Telegram-ботов
+---
+<article>
+<style>
         * {
             margin: 0;
             padding: 0;
@@ -217,8 +216,7 @@
             }
         }
     </style>
-</head>
-<body>
+
     <div class="container">
         <div class="hero">
             <div class="badge">🤖 Web Development</div>
@@ -341,9 +339,6 @@ static/             # CSS, JS, изображения</div>
             </div>
         </div>
 
-        <div style="text-align: center; margin-top: 40px;">
-            <a href="index.html" class="back-btn">← Вернуться в портфолио</a>
         </div>
-    </div>
-</body>
-</html>
+
+</article>

--- a/tts-voice-cloning-case.html
+++ b/tts-voice-cloning-case.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html>
-<html lang="ru">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>TTS Voice Cloning - Клонирование голоса</title>
-    <style>
+---
+layout: case-template
+title: TTS Voice Cloning - Клонирование голоса
+---
+<article>
+<style>
         * {
             margin: 0;
             padding: 0;
@@ -227,8 +226,7 @@
             }
         }
     </style>
-</head>
-<body>
+
     <div class="container">
         <div class="hero">
             <div class="badge">🎙️ AI Voice Tech</div>
@@ -464,9 +462,6 @@ tts.tts_to_file(
             </div>
         </div>
 
-        <div style="text-align: center; margin-top: 40px;">
-            <a href="index.html" class="back-btn">← Вернуться в портфолио</a>
         </div>
-    </div>
-</body>
-</html>
+
+</article>

--- a/yandex-market-integration-case.html
+++ b/yandex-market-integration-case.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html>
-<html lang="ru">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Yandex Market Integration - Синхронизация WooCommerce</title>
-    <style>
+---
+layout: case-template
+title: Yandex Market Integration - Синхронизация WooCommerce
+---
+<article>
+<style>
         * {
             margin: 0;
             padding: 0;
@@ -219,8 +218,7 @@
             }
         }
     </style>
-</head>
-<body>
+
     <div class="container">
         <div class="hero">
             <div class="badge">🔄 E-commerce Integration</div>
@@ -565,9 +563,6 @@ async def import_products_to_woocommerce(csv_file_path: str) -> str:
             </div>
         </div>
 
-        <div style="text-align: center; margin-top: 40px;">
-            <a href="index.html" class="back-btn">← Вернуться в портфолио</a>
         </div>
-    </div>
-</body>
-</html>
+
+</article>


### PR DESCRIPTION
## Summary
- add reusable case header include with site link and back to portfolio
- create `case-template` layout that injects the header and shared styling
- convert all `*-case.html` pages to use the new layout with YAML front matter and extracted unique content

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fbc4d74c8833194e01e9e7a218d85